### PR TITLE
Easy variable replacement

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -1,30 +1,31 @@
 #!/bin/bash
 
+plugin_name="My Awesome Plugin"
+plugin_class="My_Awesome_Plugin"
+plugin_function="my_awesome_plugin"
+plugin_path="my-awesome-plugin"
+plugin_post_type="awesome_plugin"
 
-plugin_name="Plugin Starter Template"
-plugin_class="Disciple_Tools_Plugin_Starter_Template"
-plugin_function="disciple_tools_plugin_starter_template"
-plugin_path="disciple-tools-plugin-starter-template"
-plugin_post_type="starter_post_type"
+echo -e "\nReplacing string 'Plugin Starter Template'... for '$plugin_name'."
+grep -rl --exclude-dir=*.git "Plugin Starter Template" | grep -Ev customize.sh | LANG=C xargs sed -i '' "s/Plugin Starter Template/${plugin_name}/g"
 
-
-echo -e "\nReplacing string 'Plugin Starter Template'... to '$plugin_name'."
-grep -rl "Plugin Starter Template" | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_name/g"
-#sed -i -- "s/Plugin Starter Template/$plugin_name/g" *.php
-
-echo -e "Replacing string 'Disciple_Tools_Plugin_Starter_Template'... to '$plugin_class'."
-grep -rl "Disciple_Tools_Plugin_Starter_Template" | grep -Ev customize.sh | xargs sed -i -- "s/Disciple_Tools_Plugin_Starter_Template/$plugin_class/g"
+echo -e "Replacing string 'Disciple_Tools_Plugin_Starter_Template'... for '$plugin_class'."
+grep -rl --exclude-dir=*.git "Disciple_Tools_Plugin_Starter_Template" | grep -Ev customize.sh | LANG=C xargs sed -i '' "s/Disciple_Tools_Plugin_Starter_Template/${plugin_class}/g"
 
 
-echo -e "Replacing string 'disciple_tools_plugin_starter_template'... to '$plugin_function'."
-grep -rl "disciple_tools_plugin_starter_template" | grep -Ev customize.sh | xargs sed -i -- "s/disciple_tools_plugin_starter_template/$plugin_function/g"
+echo -e "Replacing string 'disciple_tools_plugin_starter_template'... for '$plugin_function'."
+grep -rl --exclude-dir=*.git "disciple_tools_plugin_starter_template" | grep -Ev customize.sh | LANG=C xargs sed -i '' "s/disciple_tools_plugin_starter_template/${plugin_function}/g"
 
-echo -e "Replacing string 'disciple-tools-plugin-starter-template'... to '$plugin_path'."
-grep -rl "disciple-tools-plugin-starter-template" | grep -Ev customize.sh | xargs sed -i -- "s/disciple-tools-plugin-starter-template/$plugin_path/g"
+echo -e "Replacing string 'disciple-tools-plugin-starter-template'... for '$plugin_path'."
+grep -rl --exclude-dir=*.git "disciple-tools-plugin-starter-template" | grep -Ev customize.sh | LANG=C xargs sed -i '' "s/disciple-tools-plugin-starter-template/${plugin_path}/g"
 
-echo -e "Replacing string 'starter_post_type'... to '$plugin_post_type'."
-grep -rl "starter_post_type" | grep -Ev customize.sh | xargs sed -i -- "s/starter_post_type/$plugin_post_type/g"
+echo -e "Replacing string 'starter_post_type'... for '$plugin_post_type'."
+grep -rl --exclude-dir=*.git "starter_post_type" | grep -Ev customize.sh | LANG=C xargs sed -i '' "s/starter_post_type/${plugin_post_type}/g"
 
+echo -e "\nMoving disciple-tools-plugin-starter-template.php to '$plugin_path.php'"
 mv disciple-tools-plugin-starter-template.php "$plugin_path.php"
 
-echo -e "\n\nDone! Thanks for choosing Disciple.Tools."
+echo -e "\nAll replacements done. Destroying this script since it can be harmful if you re-run it."
+rm customize.sh
+
+echo -e "\nThanks for choosing Disciple.Tools!"

--- a/customize.sh
+++ b/customize.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-plugin_name="My Awesome Plugin"
-plugin_class="My_Awesome_Plugin"
-plugin_function="my_awesome_plugin"
-plugin_path="my-awesome-plugin"
-plugin_post_type="awesome_plugin"
+plugin_name="Plugin Starter Template"
+plugin_class="Disciple_Tools_Plugin_Starter_Template"
+plugin_function="disciple_tools_plugin_starter_template"
+plugin_path="disciple-tools-plugin-starter-template"
+plugin_post_type="starter_post_type"
 
 echo -e "\nReplacing string 'Plugin Starter Template'... for '$plugin_name'."
 grep -rl --exclude-dir=*.git "Plugin Starter Template" | grep -Ev customize.sh | LANG=C xargs sed -i '' "s/Plugin Starter Template/${plugin_name}/g"

--- a/customize.sh
+++ b/customize.sh
@@ -25,7 +25,7 @@ grep -rl --exclude-dir=*.git "starter_post_type" | grep -Ev customize.sh | LANG=
 echo -e "\nMoving disciple-tools-plugin-starter-template.php to '$plugin_path.php'"
 mv disciple-tools-plugin-starter-template.php "$plugin_path.php"
 
-echo -e "\nAll replacements done. Destroying this script since it can be harmful if you re-run it."
+echo -e "\nAll replacements done. Destroying this script since it can be harmful to re-run it."
 rm customize.sh
 
 echo -e "\nThanks for choosing Disciple.Tools!"

--- a/customize.sh
+++ b/customize.sh
@@ -6,7 +6,6 @@ plugin_class="Disciple_Tools_Plugin_Starter_Template"
 plugin_function="disciple_tools_plugin_starter_template"
 plugin_path="disciple-tools-plugin-starter-template"
 plugin_post_type="starter_post_type"
-foo="Yusss!"
 
 
 echo -e "\nReplacing string 'Plugin Starter Template'... to '$plugin_name'."
@@ -14,17 +13,17 @@ grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter 
 #sed -i -- "s/Plugin Starter Template/$plugin_name/g" *.php
 
 echo -e "Replacing string 'Disciple_Tools_Plugin_Starter_Template'... to '$plugin_class'."
-grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_class/g"
+grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Disciple_Tools_Plugin_Starter_Template/$plugin_class/g"
 
 
 echo -e "Replacing string 'disciple_tools_plugin_starter_template'... to '$plugin_function'."
-grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_function/g"
+grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/disciple_tools_plugin_starter_template/$plugin_function/g"
 
 echo -e "Replacing string 'disciple-tools-plugin-starter-template'... to '$plugin_path'."
-grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_path/g"
+grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/disciple-tools-plugin-starter-template/$plugin_path/g"
 
 echo -e "Replacing string 'starter_post_type'... to '$plugin_post_type'."
-grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_post_type/g"
+grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/starter_post_type/$plugin_post_type/g"
 
 mv disciple-tools-plugin-starter-template.php "$plugin_path.php"
 

--- a/customize.sh
+++ b/customize.sh
@@ -9,21 +9,21 @@ plugin_post_type="starter_post_type"
 
 
 echo -e "\nReplacing string 'Plugin Starter Template'... to '$plugin_name'."
-grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_name/g"
+grep -rl "Plugin Starter Template" | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_name/g"
 #sed -i -- "s/Plugin Starter Template/$plugin_name/g" *.php
 
 echo -e "Replacing string 'Disciple_Tools_Plugin_Starter_Template'... to '$plugin_class'."
-grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Disciple_Tools_Plugin_Starter_Template/$plugin_class/g"
+grep -rl "Disciple_Tools_Plugin_Starter_Template" | grep -Ev customize.sh | xargs sed -i -- "s/Disciple_Tools_Plugin_Starter_Template/$plugin_class/g"
 
 
 echo -e "Replacing string 'disciple_tools_plugin_starter_template'... to '$plugin_function'."
-grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/disciple_tools_plugin_starter_template/$plugin_function/g"
+grep -rl "disciple_tools_plugin_starter_template" | grep -Ev customize.sh | xargs sed -i -- "s/disciple_tools_plugin_starter_template/$plugin_function/g"
 
 echo -e "Replacing string 'disciple-tools-plugin-starter-template'... to '$plugin_path'."
-grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/disciple-tools-plugin-starter-template/$plugin_path/g"
+grep -rl "disciple-tools-plugin-starter-template" | grep -Ev customize.sh | xargs sed -i -- "s/disciple-tools-plugin-starter-template/$plugin_path/g"
 
 echo -e "Replacing string 'starter_post_type'... to '$plugin_post_type'."
-grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/starter_post_type/$plugin_post_type/g"
+grep -rl "starter_post_type" | grep -Ev customize.sh | xargs sed -i -- "s/starter_post_type/$plugin_post_type/g"
 
 mv disciple-tools-plugin-starter-template.php "$plugin_path.php"
 

--- a/customize.sh
+++ b/customize.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+
+plugin_name="Plugin Starter Template"
+plugin_class="Disciple_Tools_Plugin_Starter_Template"
+plugin_function="disciple_tools_plugin_starter_template"
+plugin_path="disciple-tools-plugin-starter-template"
+plugin_post_type="starter_post_type"
+foo="Yusss!"
+
+
+echo -e "\nReplacing string 'Plugin Starter Template'... to '$plugin_name'."
+grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_name/g"
+#sed -i -- "s/Plugin Starter Template/$plugin_name/g" *.php
+
+echo -e "Replacing string 'Disciple_Tools_Plugin_Starter_Template'... to '$plugin_class'."
+grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_class/g"
+
+
+echo -e "Replacing string 'disciple_tools_plugin_starter_template'... to '$plugin_function'."
+grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_function/g"
+
+echo -e "Replacing string 'disciple-tools-plugin-starter-template'... to '$plugin_path'."
+grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_path/g"
+
+echo -e "Replacing string 'starter_post_type'... to '$plugin_post_type'."
+grep -rl Foo\ Barz2 | grep -Ev customize.sh | xargs sed -i -- "s/Plugin Starter Template/$plugin_post_type/g"
+
+mv disciple-tools-plugin-starter-template.php "$plugin_path.php"
+
+echo -e "\n\nDone! Thanks for choosing Disciple.Tools."


### PR DESCRIPTION
Added a script that replaces all occurrences of default Plugin Starter Template strings with custom ones.

Tested for macOS Monterrey Version 12.2.1 (21D62)

**How to use:**
Replace the custom variable names for your custom plugin variables.
Make sure to respect letter case, spaces, underscores, and hyphens.

<img width="682" alt="Screen Shot 2022-05-09 at 20 44 37" src="https://user-images.githubusercontent.com/36511666/167515874-01466ab5-98fb-4e6c-a90c-f7190c7f0560.png">

After that, execute the script in a console by typing:

`./customize.sh`


You should see something like this:

![Screen Shot 2022-05-09 at 20 44 04](https://user-images.githubusercontent.com/36511666/167515816-737de171-4cba-482a-84c7-a937a3c3567a.png)
